### PR TITLE
Add `vel_differentiator_gain` to the ODrive interface.

### DIFF
--- a/Firmware/odrive-interface.yaml
+++ b/Firmware/odrive-interface.yaml
@@ -1091,6 +1091,10 @@ interfaces:
             type: float32
             unit: N·m / (turn/s * s)
             doc: units = N·m / (turn/s * s)
+          vel_differentiator_gain:
+            type: float32
+            unit: N·m / turn
+            doc: units = N·m / turn
           vel_integrator_limit:
             type: float32
             unit: N·m


### PR DESCRIPTION
On our Robots we want to configure the `vel_differentiator_gain` in order to acess this value we need to add it to the `odrive-interface.yaml`.